### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -13,7 +13,7 @@
    "build-depends" : [],
    "tags" : [ "rhythm", "algorithm", "euclid" ],
    "perl" : "6.c",
-   "license" : "perl",
+   "license" : "Artistic-2.0",
    "support" : {
       "source" : "git@github.com:jonathanstowe/EuclideanRhythm.git"
    }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license